### PR TITLE
Specify meta.defaultOptions for all rules with a schema

### DIFF
--- a/.changeset/default-options.md
+++ b/.changeset/default-options.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-jsx-a11y-x': minor
+---
+
+Add `defaultOptions` to all rules that take options.

--- a/src/rules/alt-text.js
+++ b/src/rules/alt-text.js
@@ -210,12 +210,13 @@ export default {
         'Enforce all elements that require alternative text have meaningful information to relay back to end user.',
     },
     schema: [schema],
+    defaultOptions: [{ elements: DEFAULT_ELEMENTS }],
   },
 
   create: (context) => {
     const options = context.options[0] || {};
     // Elements to validate for alt text.
-    const elementOptions = options.elements || DEFAULT_ELEMENTS;
+    const elementOptions = options.elements;
     // Get custom components for just the elements that will be tested.
     const customComponents = elementOptions.flatMap(
       (element) => options[element],

--- a/src/rules/anchor-has-content.js
+++ b/src/rules/anchor-has-content.js
@@ -25,6 +25,7 @@ export default {
       description: 'Enforce all anchors to contain accessible content.',
     },
     schema: [schema],
+    defaultOptions: [{ components: [] }],
   },
 
   create: (context) => {
@@ -32,7 +33,7 @@ export default {
     return {
       JSXOpeningElement: (node) => {
         const options = context.options[0] || {};
-        const componentOptions = options.components || [];
+        const componentOptions = options.components;
         const typeCheck = ['a'].concat(componentOptions);
         const nodeType = elementType(node);
 

--- a/src/rules/aria-role.js
+++ b/src/rules/aria-role.js
@@ -26,7 +26,6 @@ const schema = generateObjSchema({
   },
   ignoreNonDOM: {
     type: 'boolean',
-    default: false,
   },
 });
 
@@ -42,12 +41,13 @@ export default {
         'Enforce that elements with ARIA roles must use a valid, non-abstract ARIA role.',
     },
     schema: [schema],
+    defaultOptions: [{ allowedInvalidRoles: [], ignoreNonDOM: false }],
   },
 
   create: (context) => {
     const options = context.options[0] || {};
-    const ignoreNonDOM = !!options.ignoreNonDOM;
-    const allowedInvalidRoles = new Set(options.allowedInvalidRoles || []);
+    const ignoreNonDOM = options.ignoreNonDOM;
+    const allowedInvalidRoles = new Set(options.allowedInvalidRoles);
     const elementType = getElementType(context);
 
     return {

--- a/src/rules/autocomplete-valid.js
+++ b/src/rules/autocomplete-valid.js
@@ -22,6 +22,7 @@ export default {
       description: 'Enforce that autocomplete attributes are used correctly.',
     },
     schema: [schema],
+    defaultOptions: [{ inputComponents: [] }],
   },
 
   create: (context) => {
@@ -29,7 +30,7 @@ export default {
     return {
       JSXOpeningElement: (node) => {
         const options = context.options[0] || {};
-        const { inputComponents = [] } = options;
+        const { inputComponents } = options;
         const inputTypes = ['input'].concat(inputComponents);
 
         const elType = elementType(node);

--- a/src/rules/heading-has-content.js
+++ b/src/rules/heading-has-content.js
@@ -27,6 +27,7 @@ export default {
         'Enforce heading (`h1`, `h2`, etc) elements contain accessible content.',
     },
     schema: [schema],
+    defaultOptions: [{ components: [] }],
   },
 
   create: (context) => {
@@ -34,7 +35,7 @@ export default {
     return {
       JSXOpeningElement: (node) => {
         const options = context.options[0] || {};
-        const componentOptions = options.components || [];
+        const componentOptions = options.components;
         const typeCheck = headings.concat(componentOptions);
         const nodeType = elementType(node);
 

--- a/src/rules/img-redundant-alt.js
+++ b/src/rules/img-redundant-alt.js
@@ -50,6 +50,7 @@ export default {
         'Enforce `<img>` alt prop does not contain the word "image", "picture", or "photo".',
     },
     schema: [schema],
+    defaultOptions: [{ components: [], words: [] }],
   },
 
   create: (context) => {
@@ -57,7 +58,7 @@ export default {
     return {
       JSXOpeningElement: (node) => {
         const options = context.options[0] || {};
-        const componentOptions = options.components || [];
+        const componentOptions = options.components;
         const typesToValidate = ['img'].concat(componentOptions);
         const nodeType = elementType(node);
 
@@ -76,7 +77,7 @@ export default {
         const isVisible =
           isHiddenFromScreenReader(nodeType, node.attributes) === false;
 
-        const { words = [] } = options;
+        const { words } = options;
         const redundantWords = REDUNDANT_WORDS.concat(words);
 
         if (typeof value === 'string' && isVisible) {

--- a/src/rules/no-autofocus.js
+++ b/src/rules/no-autofocus.js
@@ -18,7 +18,6 @@ const errorMessage =
 const schema = generateObjSchema({
   ignoreNonDOM: {
     type: 'boolean',
-    default: false,
   },
 });
 
@@ -29,6 +28,7 @@ export default {
       description: 'Enforce autoFocus prop is not enabled.',
     },
     schema: [schema],
+    defaultOptions: [{ ignoreNonDOM: false }],
   },
 
   create: (context) => {
@@ -38,7 +38,7 @@ export default {
         // Determine if ignoreNonDOM is set to true
         // If true, then do not run rule.
         const options = context.options[0] || {};
-        const ignoreNonDOM = !!options.ignoreNonDOM;
+        const ignoreNonDOM = options.ignoreNonDOM;
 
         if (ignoreNonDOM) {
           const type = elementType(attribute.parent);

--- a/src/rules/no-distracting-elements.js
+++ b/src/rules/no-distracting-elements.js
@@ -26,6 +26,7 @@ export default {
       description: 'Enforce distracting elements are not used.',
     },
     schema: [schema],
+    defaultOptions: [{ elements: DEFAULT_ELEMENTS }],
   },
 
   create: (context) => {
@@ -33,7 +34,7 @@ export default {
     return {
       JSXOpeningElement: (node) => {
         const options = context.options[0] || {};
-        const elementOptions = options.elements || DEFAULT_ELEMENTS;
+        const elementOptions = options.elements;
         const type = elementType(node);
         const distractingElement = elementOptions.find(
           (element) => type === element,


### PR DESCRIPTION
When trying to upgrade eslint-plugin-eslint-plugin to the latest version, the following new errors were emitted:

```
.../src/rules/alt-text.js
  206:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

.../src/rules/anchor-has-content.js
  22:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

.../src/rules/aria-role.js
  38:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

.../src/rules/autocomplete-valid.js
  19:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

.../src/rules/heading-has-content.js
  23:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

.../src/rules/img-redundant-alt.js
  46:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

.../src/rules/no-autofocus.js
  26:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

.../src/rules/no-distracting-elements.js
  23:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options
```

Configuring options and option defaults is discussed in the eslint custom rules documentation at:

https://eslint.org/docs/latest/extend/custom-rules#option-defaults

Adding the default options allows removing fallback values inside the rule logic.

Once the defaults are applied, the eslint-plugin-eslint-plugin can be updated.