### PR TITLE
Fix additional eslint-plugin errors found when removing flow support

### DIFF
--- a/src/rules/anchor-ambiguous-text.js
+++ b/src/rules/anchor-ambiguous-text.js
@@ -34,6 +34,7 @@ export default ({
         'Enforce `<a>` text to not exactly match "click here", "here", "link", or "a link".',
     },
     schema: [schema],
+    defaultOptions: [{ words: DEFAULT_AMBIGUOUS_WORDS }],
   },
 
   create: (context: ESLintContext) => {
@@ -42,7 +43,7 @@ export default ({
     const typesToValidate = ['a'];
 
     const options = context.options[0] || {};
-    const { words = DEFAULT_AMBIGUOUS_WORDS } = options;
+    const { words } = options;
     const ambiguousWords = new Set(words);
 
     return {

--- a/src/rules/anchor-is-valid.js
+++ b/src/rules/anchor-is-valid.js
@@ -47,6 +47,7 @@ export default ({
       description: 'Enforce all anchors are valid, navigable elements.',
     },
     schema: [schema],
+    defaultOptions: [{ components: [], specialLink: [], aspects: allAspects }],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {
@@ -57,7 +58,7 @@ export default ({
       JSXOpeningElement: (node: JSXOpeningElement): void => {
         const { attributes } = node;
         const options = context.options[0] || {};
-        const componentOptions = options.components || [];
+        const componentOptions = options.components;
         const typeCheck = ['a'].concat(componentOptions);
         const nodeType = elementType(node);
 
@@ -67,7 +68,7 @@ export default ({
         }
 
         // Set up the rule aspects to check.
-        const aspects = options.aspects || allAspects;
+        const aspects = options.aspects;
 
         // Create active aspect flag object. Failing checks will only report
         // if the related flag is set to true.
@@ -76,7 +77,7 @@ export default ({
           activeAspects[aspect] = aspects.indexOf(aspect) !== -1;
         });
 
-        const propOptions = options.specialLink || [];
+        const propOptions = options.specialLink;
         const propsToValidate = ['href'].concat(propOptions);
         const values = propsToValidate.map((prop) =>
           getPropValue(getProp(node.attributes, prop)),

--- a/src/rules/control-has-associated-label.js
+++ b/src/rules/control-has-associated-label.js
@@ -47,17 +47,21 @@ export default ({
       url: 'https://github.com/es-tooling/eslint-plugin-jsx-a11y-x/tree/HEAD/docs/rules/control-has-associated-label.md',
     },
     schema: [schema],
+    defaultOptions: [
+      {
+        labelAttributes: [],
+        controlComponents: [],
+        ignoreElements: [],
+        ignoreRoles: [],
+      },
+    ],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {
     const elementType = getElementType(context);
     const options = context.options[0] || {};
-    const {
-      labelAttributes = [],
-      controlComponents = [],
-      ignoreElements = [],
-      ignoreRoles = [],
-    } = options;
+    const { labelAttributes, controlComponents, ignoreElements, ignoreRoles } =
+      options;
 
     const newIgnoreElements = new Set([...ignoreElements, ...ignoreList]);
 

--- a/src/rules/interactive-supports-focus.js
+++ b/src/rules/interactive-supports-focus.js
@@ -66,6 +66,7 @@ export default ({
         'Add `tabIndex={-1}` to make the element focusable but not reachable via sequential keyboard navigation.',
     },
     schema: [schema],
+    defaultOptions: [{ tabbable: [] }],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {
@@ -73,10 +74,7 @@ export default ({
     return {
       JSXOpeningElement: (node: JSXOpeningElement) => {
         const tabbable =
-          (context.options &&
-            context.options[0] &&
-            context.options[0].tabbable) ||
-          [];
+          context.options && context.options[0] && context.options[0].tabbable;
         const { attributes } = node;
         const type = elementType(node);
         const hasInteractiveProps = hasAnyProp(attributes, interactiveProps);

--- a/src/rules/label-has-associated-control.js
+++ b/src/rules/label-has-associated-control.js
@@ -74,12 +74,21 @@ export default ({
       url: 'https://github.com/es-tooling/eslint-plugin-jsx-a11y-x/tree/HEAD/docs/rules/label-has-associated-control.md',
     },
     schema: [schema],
+    defaultOptions: [
+      {
+        labelComponents: [],
+        labelAttributes: [],
+        controlComponents: [],
+        assert: 'either',
+        depth: 2,
+      },
+    ],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {
     const options = context.options[0] || {};
-    const labelComponents = options.labelComponents || [];
-    const assertType = options.assert || 'either';
+    const labelComponents = options.labelComponents;
+    const assertType = options.assert;
     const labelComponentNames = ['label'].concat(labelComponents);
     const elementType = getElementType(context);
 
@@ -98,13 +107,10 @@ export default ({
         'progress',
         'select',
         'textarea',
-        ...(options.controlComponents || []),
+        ...options.controlComponents,
       ];
       // Prevent crazy recursion.
-      const recursionDepth = Math.min(
-        options.depth === undefined ? 2 : options.depth,
-        25,
-      );
+      const recursionDepth = Math.min(options.depth, 25);
       const hasHtmlFor = validateHtmlFor(node.openingElement, context);
       // Check for multiple control components.
       const hasNestedControl = controlComponents.some((name) =>

--- a/src/rules/media-has-caption.js
+++ b/src/rules/media-has-caption.js
@@ -40,7 +40,7 @@ const isMediaType = (context, type) => {
 const isTrackType = (context, type) => {
   const options = context.options[0] || {};
   return ['track']
-    .concat(options.track || [])
+    .concat(options.track)
     .some((typeToCheck) => typeToCheck === type);
 };
 
@@ -52,6 +52,7 @@ export default ({
         'Enforces that `<audio>` and `<video>` elements must have a `<track>` for captions.',
     },
     schema: [schema],
+    defaultOptions: [{ audio: [], video: [], track: [] }],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {

--- a/src/rules/mouse-events-have-key-events.js
+++ b/src/rules/mouse-events-have-key-events.js
@@ -37,6 +37,12 @@ export default ({
         'Enforce that `onMouseOver`/`onMouseOut` are accompanied by `onFocus`/`onBlur` for keyboard-only users.',
     },
     schema: [schema],
+    defaultOptions: [
+      {
+        hoverInHandlers: DEFAULT_HOVER_IN_HANDLERS,
+        hoverOutHandlers: DEFAULT_HOVER_OUT_HANDLERS,
+      },
+    ],
   },
 
   create: (context: ESLintContext) => ({
@@ -49,10 +55,8 @@ export default ({
 
       const { options } = context;
 
-      const hoverInHandlers: string[] =
-        options[0]?.hoverInHandlers ?? DEFAULT_HOVER_IN_HANDLERS;
-      const hoverOutHandlers: string[] =
-        options[0]?.hoverOutHandlers ?? DEFAULT_HOVER_OUT_HANDLERS;
+      const hoverInHandlers: string[] = options[0]?.hoverInHandlers;
+      const hoverOutHandlers: string[] = options[0]?.hoverOutHandlers;
 
       const { attributes } = node;
 

--- a/src/rules/no-interactive-element-to-noninteractive-role.js
+++ b/src/rules/no-interactive-element-to-noninteractive-role.js
@@ -43,8 +43,11 @@ export default ({
           },
           uniqueItems: true,
         },
+        description:
+          'An object mapping element types to arrays of non-interactive roles that are allowed for those elements.',
       },
     ],
+    defaultOptions: [{}],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {

--- a/src/rules/no-noninteractive-element-interactions.js
+++ b/src/rules/no-noninteractive-element-interactions.js
@@ -53,6 +53,7 @@ export default ({
         'Disallow non-interactive elements being assigned mouse or keyboard event listeners.',
     },
     schema: [schema],
+    defaultOptions: [{ handlers: defaultInteractiveProps }],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {

--- a/src/rules/no-noninteractive-element-to-interactive-role.js
+++ b/src/rules/no-noninteractive-element-to-interactive-role.js
@@ -43,8 +43,11 @@ export default ({
           },
           uniqueItems: true,
         },
+        description:
+          'An object mapping element types to arrays of interactive roles that are allowed for those elements.',
       },
     ],
+    defaultOptions: [{}],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {

--- a/src/rules/no-noninteractive-tabindex.js
+++ b/src/rules/no-noninteractive-tabindex.js
@@ -45,6 +45,7 @@ export default ({
         'Enforce `tabIndex` only be declared on interactive elements.',
     },
     schema: [schema],
+    defaultOptions: [{ roles: [], tags: [] }],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {
@@ -69,10 +70,10 @@ export default ({
         }
         // Allow for configuration overrides.
         const { tags, roles, allowExpressionValues } = options[0] || {};
-        if (tags && tags.includes(type)) {
+        if (tags.includes(type)) {
           return;
         }
-        if (roles && roles.includes(role)) {
+        if (roles.includes(role)) {
           return;
         }
         if (

--- a/src/rules/no-redundant-roles.js
+++ b/src/rules/no-redundant-roles.js
@@ -41,8 +41,11 @@ export default ({
           },
           uniqueItems: true,
         },
+        description:
+          'An object mapping element types to arrays of roles that are allowed to be redundant for those elements.',
       },
     ],
+    defaultOptions: [{}],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {

--- a/src/rules/no-static-element-interactions.js
+++ b/src/rules/no-static-element-interactions.js
@@ -52,6 +52,7 @@ export default ({
         'Enforce that non-interactive, visible elements (such as `<div>`) that have click handlers use the role attribute.',
     },
     schema: [schema],
+    defaultOptions: [{ handlers: defaultInteractiveProps }],
   },
 
   create: (context: ESLintContext): ESLintVisitorSelectorConfig => {
@@ -62,8 +63,7 @@ export default ({
         const { attributes } = node;
         const type = elementType(node);
 
-        const { allowExpressionValues, handlers = defaultInteractiveProps } =
-          options[0] || {};
+        const { allowExpressionValues, handlers } = options[0] || {};
 
         const hasInteractiveProps = handlers.some(
           (prop) =>


### PR DESCRIPTION
After removing flow support, new eslint-plugin started emitting in CI. These were:

```
/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/anchor-ambiguous-text.js
Error:   28:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/anchor-is-valid.js
Error:   37:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/control-has-associated-label.js
Error:   36:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/interactive-supports-focus.js
Error:   48:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/label-has-associated-control.js
Error:   63:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/media-has-caption.js
Error:   40:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/mouse-events-have-key-events.js
Error:   31:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/no-interactive-element-to-noninteractive-role.js
Error:   22:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options
Error:   29:7  error  Schema option is missing an ajv description                             eslint-plugin/require-meta-schema-description

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/no-noninteractive-element-interactions.js
Error:   42:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/no-noninteractive-element-to-interactive-role.js
Error:   22:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options
Error:   29:7  error  Schema option is missing an ajv description                             eslint-plugin/require-meta-schema-description

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/no-noninteractive-tabindex.js
Error:   34:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/no-redundant-roles.js
Error:   21:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options
Error:   28:7  error  Schema option is missing an ajv description                             eslint-plugin/require-meta-schema-description

/home/runner/work/eslint-plugin-jsx-a11y-x/eslint-plugin-jsx-a11y-x/src/rules/no-static-element-interactions.js
Error:   41:9  error  Rule with non-empty schema is missing a `meta.defaultOptions` property  eslint-plugin/require-meta-default-options
```