### PR TITLE
Remove support for Node 18

### DIFF
--- a/.changeset/node.md
+++ b/.changeset/node.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-jsx-a11y-x': minor
+---
+
+Remove support for Node.js 18. Now requires Node.js 20+.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node:
-          - 18
           - 20
           - 22
           - 24

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+    "node": "^20.9.0 || >=21.1.0"
   },
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
This aligns the Node versions supported with that of upstream eslint: 20, 22, 24+.