### PR TITLE
Restore eslint version install to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
 
+      - name: Install ESLint ${{ matrix.eslint }}
+        if: ${{ matrix.eslint }}
+        run: pnpm add --save-dev eslint@${{ matrix.eslint }} @eslint/js@${{ matrix.eslint }}
+
       - name: Install Dependencies
         run: pnpm install
 


### PR DESCRIPTION
Since commit b167ac4d6fd5f5349363ee652e62c003ade55edb, the eslint version install has been commented out in the CI workflow. Then in commit d26b1e7914f98321ee08168bbc647d6a12d03b47 it was fully removed. As a result, the CI test matrix is no longer working as intended as only the eslint version in the lockfile is being tested.