### PR TITLE
Remove support for EOL eslint 8

### DIFF
--- a/.changeset/eol.md
+++ b/.changeset/eol.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-jsx-a11y-x': minor
+---
+
+Remove support for eslint 8.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           - 22
           - 24
         eslint:
-          - 8.56
-          - 8
           - 9
 
         include:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "tests-only": "vitest run --coverage"
   },
   "peerDependencies": {
-    "eslint": "^8.57.0 || ^9.0.0"
+    "eslint": "^9.0.0"
   },
   "dependencies": {
     "aria-query": "^5.3.2",


### PR DESCRIPTION
Per the eslint version support page:

https://eslint.org/version-support/

eslint version 8 has been end-of-life (EOL) since 2024-10-05. It is no longer receiving updates for bugs or security issues. This change aligns support with upstream to reduce testing and maintenance overhead.