### PR TITLE
Update minimatch to 10.2.5

### DIFF
--- a/.changeset/minimatch.md
+++ b/.changeset/minimatch.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-jsx-a11y-x': minor
+---
+
+Update minimatch dependency to 10.2.5.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "damerau-levenshtein": "^1.0.8",
     "jsx-ast-utils-x": "^0.1.0",
     "language-tags": "^1.0.9",
-    "minimatch": "^3.1.2"
+    "minimatch": "^10.2.5"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.0.9
         version: 1.0.9
       minimatch:
-        specifier: ^3.1.2
-        version: 3.1.5
+        specifier: ^10.2.5
+        version: 10.2.5
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.1

--- a/src/rules/label-has-associated-control.js
+++ b/src/rules/label-has-associated-control.js
@@ -8,7 +8,7 @@
 // ----------------------------------------------------------------------------
 
 import jsxAstUtils from 'jsx-ast-utils-x';
-import minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 import { generateObjSchema, arraySchema } from '../util/schemas.js';
 import getElementType from '../util/getElementType.js';
 import mayContainChildComponent from '../util/mayContainChildComponent.js';

--- a/src/util/mayContainChildComponent.js
+++ b/src/util/mayContainChildComponent.js
@@ -6,7 +6,7 @@
  */
 
 import jsxAstUtils from 'jsx-ast-utils-x';
-import minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 
 const { elementType: rawElementType } = jsxAstUtils;
 

--- a/src/util/mayHaveAccessibleLabel.js
+++ b/src/util/mayHaveAccessibleLabel.js
@@ -6,7 +6,7 @@
  */
 
 import jsxAstUtils from 'jsx-ast-utils-x';
-import minimatch from 'minimatch';
+import { minimatch } from 'minimatch';
 
 const { getPropValue, propName, elementType: rawElementType } = jsxAstUtils;
 


### PR DESCRIPTION
This change updates the minimatch dependency from 3.1.2 to 10.2.5.

In addition to aligning with updated minimatch releases, improvements, and security fixes, it also updates to a version of minimatch that includes TypeScript types, a stepping stone for this project to also adopt TypeScript.