### PR TITLE
Remove invalid "type" from rule-tester invalid cases

### DIFF
--- a/__tests__/src/rules/alt-text.spec.js
+++ b/__tests__/src/rules/alt-text.spec.js
@@ -20,13 +20,11 @@ const ruleTester = new RuleTester();
 
 const missingPropError = (type) => ({
   message: `${type} elements must have an alt prop, either with meaningful text, or an empty string for decorative images.`,
-  type: 'JSXOpeningElement',
 });
 
 const altValueError = (type) => ({
   message: `Invalid alt value for ${type}. \
 Use alt="" for presentational images.`,
-  type: 'JSXOpeningElement',
 });
 
 const ariaLabelValueError = {
@@ -41,7 +39,6 @@ const ariaLabelledbyValueError = {
 const preferAltError = () => ({
   message:
     'Prefer alt="" over a presentational role. First rule of aria is to not use aria if it can be achieved via native HTML.',
-  type: 'JSXOpeningElement',
 });
 
 const objectError = {

--- a/__tests__/src/rules/anchor-ambiguous-text.spec.js
+++ b/__tests__/src/rules/anchor-ambiguous-text.spec.js
@@ -29,7 +29,6 @@ const DEFAULT_AMBIGUOUS_WORDS = [
 
 const expectedErrorGenerator = (words) => ({
   message: `Ambiguous text within anchor. Screen reader users rely on link text for context; the words "${words.join('", "')}" are ambiguous and do not provide enough context.`,
-  type: 'JSXOpeningElement',
 });
 
 const expectedError = expectedErrorGenerator(DEFAULT_AMBIGUOUS_WORDS);

--- a/__tests__/src/rules/anchor-has-content.spec.js
+++ b/__tests__/src/rules/anchor-has-content.spec.js
@@ -21,7 +21,6 @@ const ruleTester = new RuleTester();
 const expectedError = {
   message:
     'Anchors must have content and the content must be accessible by a screen reader.',
-  type: 'JSXOpeningElement',
 };
 
 ruleTester.run('anchor-has-content', rule, {

--- a/__tests__/src/rules/anchor-is-valid.spec.js
+++ b/__tests__/src/rules/anchor-is-valid.spec.js
@@ -30,15 +30,12 @@ const invalidHrefErrorMessage =
 
 const preferButtonexpectedError = {
   message: preferButtonErrorMessage,
-  type: 'JSXOpeningElement',
 };
 const noHrefexpectedError = {
   message: noHrefErrorMessage,
-  type: 'JSXOpeningElement',
 };
 const invalidHrefexpectedError = {
   message: invalidHrefErrorMessage,
-  type: 'JSXOpeningElement',
 };
 
 const components = [

--- a/__tests__/src/rules/aria-activedescendant-has-tabindex.spec.js
+++ b/__tests__/src/rules/aria-activedescendant-has-tabindex.spec.js
@@ -21,7 +21,6 @@ const ruleTester = new RuleTester();
 const expectedError = {
   message:
     'An element that manages focus with `aria-activedescendant` must have a tabindex',
-  type: 'JSXOpeningElement',
 };
 
 ruleTester.run('aria-activedescendant-has-tabindex', rule, {

--- a/__tests__/src/rules/aria-props.spec.js
+++ b/__tests__/src/rules/aria-props.spec.js
@@ -27,13 +27,11 @@ const errorMessage = (name) => {
 
   if (suggestions.length > 0) {
     return {
-      type: 'JSXAttribute',
       message: `${message} Did you mean to use ${suggestions}?`,
     };
   }
 
   return {
-    type: 'JSXAttribute',
     message,
   };
 };

--- a/__tests__/src/rules/aria-role.spec.js
+++ b/__tests__/src/rules/aria-role.spec.js
@@ -21,7 +21,6 @@ const ruleTester = new RuleTester();
 
 const errorMessage = {
   message: 'Elements with ARIA roles must use a valid, non-abstract ARIA role.',
-  type: 'JSXAttribute',
 };
 
 const roleKeys = roles.keys();

--- a/__tests__/src/rules/aria-unsupported-elements.spec.js
+++ b/__tests__/src/rules/aria-unsupported-elements.spec.js
@@ -23,7 +23,6 @@ const ruleTester = new RuleTester();
 const errorMessage = (invalidProp) => ({
   message: `This element does not support ARIA roles, states and properties. \
 Try removing the prop '${invalidProp}'.`,
-  type: 'JSXOpeningElement',
 });
 
 const domElements = dom.keys();

--- a/__tests__/src/rules/autocomplete-valid.spec.js
+++ b/__tests__/src/rules/autocomplete-valid.spec.js
@@ -22,14 +22,12 @@ const ruleTester = new RuleTester();
 const invalidAutocomplete = [
   {
     message: axeFailMessage('autocomplete-valid'),
-    type: 'JSXOpeningElement',
   },
 ];
 
 const inappropriateAutocomplete = [
   {
     message: axeFailMessage('autocomplete-appropriate'),
-    type: 'JSXOpeningElement',
   },
 ];
 

--- a/__tests__/src/rules/click-events-have-key-events.spec.js
+++ b/__tests__/src/rules/click-events-have-key-events.spec.js
@@ -24,7 +24,6 @@ const errorMessage =
 
 const expectedError = {
   message: errorMessage,
-  type: 'JSXOpeningElement',
 };
 
 ruleTester.run('click-events-have-key-events', rule, {

--- a/__tests__/src/rules/control-has-associated-label.spec.js
+++ b/__tests__/src/rules/control-has-associated-label.spec.js
@@ -26,7 +26,6 @@ const ruleName = 'jsx-a11y-x/control-has-associated-label';
 
 const expectedError = {
   message: 'A control must be associated with a text label.',
-  type: 'JSXOpeningElement',
 };
 
 const alwaysValid = [

--- a/__tests__/src/rules/heading-has-content.spec.js
+++ b/__tests__/src/rules/heading-has-content.spec.js
@@ -21,7 +21,6 @@ const ruleTester = new RuleTester();
 const expectedError = {
   message:
     'Headings must have content and the content must be accessible by a screen reader.',
-  type: 'JSXOpeningElement',
 };
 
 const components = [

--- a/__tests__/src/rules/html-has-lang.spec.js
+++ b/__tests__/src/rules/html-has-lang.spec.js
@@ -20,7 +20,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message: '<html> elements must have the lang prop.',
-  type: 'JSXOpeningElement',
 };
 
 ruleTester.run('html-has-lang', rule, {

--- a/__tests__/src/rules/iframe-has-title.spec.js
+++ b/__tests__/src/rules/iframe-has-title.spec.js
@@ -20,7 +20,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message: '<iframe> elements must have a unique title property.',
-  type: 'JSXOpeningElement',
 };
 
 const componentsSettings = {

--- a/__tests__/src/rules/img-redundant-alt.spec.js
+++ b/__tests__/src/rules/img-redundant-alt.spec.js
@@ -40,7 +40,6 @@ const ruleTester = new RuleTester();
 const expectedError = {
   message:
     'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt prop.',
-  type: 'JSXOpeningElement',
 };
 
 ruleTester.run('img-redundant-alt', rule, {

--- a/__tests__/src/rules/interactive-supports-focus.spec.js
+++ b/__tests__/src/rules/interactive-supports-focus.spec.js
@@ -33,7 +33,6 @@ function template(strings, ...keys) {
 }
 
 const ruleName = 'interactive-supports-focus';
-const type = 'JSXOpeningElement';
 const codeTemplate = template`<${0} role="${1}" ${2}={() => void 0} />`;
 const fixedTemplate = template`<${0} tabIndex={${1}} role="${2}" ${3}={() => void 0} />`;
 const tabindexTemplate = template`<${0} role="${1}" ${2}={() => void 0} tabIndex="0" />`;
@@ -56,7 +55,6 @@ const buttonError = {
       output: '<Div tabIndex={0} onClick={() => void 0} role="button" />',
     },
   ],
-  type,
 };
 
 const recommendedOptions =
@@ -232,7 +230,6 @@ const failReducer = (roles, handlers, messageTemplate) =>
                 code: codeTemplate(element, role, handler),
                 errors: [
                   {
-                    type,
                     message: messageTemplate(role),
                     suggestions: [
                       {

--- a/__tests__/src/rules/label-has-associated-control.spec.js
+++ b/__tests__/src/rules/label-has-associated-control.spec.js
@@ -33,7 +33,6 @@ const expectedErrors = {};
 Object.keys(errorMessages).forEach((key) => {
   expectedErrors[key] = {
     message: errorMessages[key],
-    type: 'JSXOpeningElement',
   };
 });
 

--- a/__tests__/src/rules/lang.spec.js
+++ b/__tests__/src/rules/lang.spec.js
@@ -20,7 +20,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message: 'lang attribute must have a valid value.',
-  type: 'JSXAttribute',
 };
 
 const componentsSettings = {

--- a/__tests__/src/rules/media-has-caption.spec.js
+++ b/__tests__/src/rules/media-has-caption.spec.js
@@ -21,7 +21,6 @@ const ruleTester = new RuleTester();
 const expectedError = {
   message:
     'Media elements such as <audio> and <video> must have a <track> for captions.',
-  type: 'JSXOpeningElement',
 };
 
 const customSchema = [

--- a/__tests__/src/rules/mouse-events-have-key-events.spec.js
+++ b/__tests__/src/rules/mouse-events-have-key-events.spec.js
@@ -20,19 +20,15 @@ const ruleTester = new RuleTester();
 
 const mouseOverError = {
   message: 'onMouseOver must be accompanied by onFocus for accessibility.',
-  type: 'JSXAttribute',
 };
 const pointerEnterError = {
   message: 'onPointerEnter must be accompanied by onFocus for accessibility.',
-  type: 'JSXAttribute',
 };
 const mouseOutError = {
   message: 'onMouseOut must be accompanied by onBlur for accessibility.',
-  type: 'JSXAttribute',
 };
 const pointerLeaveError = {
   message: 'onPointerLeave must be accompanied by onBlur for accessibility.',
-  type: 'JSXAttribute',
 };
 
 ruleTester.run('mouse-events-have-key-events', rule, {

--- a/__tests__/src/rules/no-access-key.spec.js
+++ b/__tests__/src/rules/no-access-key.spec.js
@@ -21,7 +21,6 @@ const ruleTester = new RuleTester();
 const expectedError = {
   message:
     'No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard commands used by screen readers and keyboard-only users create a11y complications.',
-  type: 'JSXOpeningElement',
 };
 
 ruleTester.run('no-access-key', rule, {

--- a/__tests__/src/rules/no-aria-hidden-on-focusable.spec.js
+++ b/__tests__/src/rules/no-aria-hidden-on-focusable.spec.js
@@ -20,7 +20,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message: 'aria-hidden="true" must not be set on focusable elements.',
-  type: 'JSXOpeningElement',
 };
 
 ruleTester.run('no-aria-hidden-on-focusable', rule, {

--- a/__tests__/src/rules/no-autofocus.spec.js
+++ b/__tests__/src/rules/no-autofocus.spec.js
@@ -21,7 +21,6 @@ const ruleTester = new RuleTester();
 const expectedError = {
   message:
     'The autoFocus prop should not be enabled, as it can reduce usability and accessibility for users.',
-  type: 'JSXAttribute',
 };
 
 const ignoreNonDOMSchema = [

--- a/__tests__/src/rules/no-distracting-elements.spec.js
+++ b/__tests__/src/rules/no-distracting-elements.spec.js
@@ -20,7 +20,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = (element) => ({
   message: `Do not use <${element}> elements as they can create visual accessibility issues and are deprecated.`,
-  type: 'JSXOpeningElement',
 });
 
 const componentsSettings = {

--- a/__tests__/src/rules/no-interactive-element-to-noninteractive-role.spec.js
+++ b/__tests__/src/rules/no-interactive-element-to-noninteractive-role.spec.js
@@ -27,7 +27,6 @@ const errorMessage =
 
 const expectedError = {
   message: errorMessage,
-  type: 'JSXAttribute',
 };
 
 const ruleName = 'jsx-a11y-x/no-interactive-element-to-noninteractive-role';

--- a/__tests__/src/rules/no-noninteractive-element-interactions.spec.js
+++ b/__tests__/src/rules/no-noninteractive-element-interactions.spec.js
@@ -27,7 +27,6 @@ const errorMessage =
 
 const expectedError = {
   message: errorMessage,
-  type: 'JSXOpeningElement',
 };
 
 const ruleName = 'no-noninteractive-element-interactions';

--- a/__tests__/src/rules/no-noninteractive-element-to-interactive-role.spec.js
+++ b/__tests__/src/rules/no-noninteractive-element-to-interactive-role.spec.js
@@ -29,7 +29,6 @@ const errorMessage =
 
 const expectedError = {
   message: errorMessage,
-  type: 'JSXAttribute',
 };
 
 const ruleName = 'jsx-a11y-x/no-noninteractive-element-to-interactive-role';

--- a/__tests__/src/rules/no-noninteractive-tabindex.spec.js
+++ b/__tests__/src/rules/no-noninteractive-tabindex.spec.js
@@ -26,7 +26,6 @@ const ruleName = 'no-noninteractive-tabindex';
 
 const expectedError = {
   message: '`tabIndex` should only be declared on interactive elements.',
-  type: 'JSXAttribute',
 };
 
 const componentsSettings = {

--- a/__tests__/src/rules/no-redundant-roles.spec.js
+++ b/__tests__/src/rules/no-redundant-roles.spec.js
@@ -22,7 +22,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = (element, implicitRole) => ({
   message: `The element ${element} has an implicit role of ${implicitRole}. Defining this explicitly is redundant and should be avoided.`,
-  type: 'JSXOpeningElement',
 });
 
 const ruleName = 'jsx-a11y-x/no-redundant-roles';

--- a/__tests__/src/rules/no-static-element-interactions.spec.js
+++ b/__tests__/src/rules/no-static-element-interactions.spec.js
@@ -27,7 +27,6 @@ const errorMessage =
 
 const expectedError = {
   message: errorMessage,
-  type: 'JSXOpeningElement',
 };
 
 const ruleName = 'no-static-element-interactions';

--- a/__tests__/src/rules/prefer-tag-over-role.spec.js
+++ b/__tests__/src/rules/prefer-tag-over-role.spec.js
@@ -7,7 +7,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = (role, tag) => ({
   message: `Use ${tag} instead of the "${role}" role to ensure accessibility across all devices.`,
-  type: 'JSXOpeningElement',
 });
 
 ruleTester.run('prefer-tag-over-role', rule, {

--- a/__tests__/src/rules/role-has-required-aria-props.spec.js
+++ b/__tests__/src/rules/role-has-required-aria-props.spec.js
@@ -26,7 +26,6 @@ const errorMessage = (role) => {
 
   return {
     message: `Elements with the ARIA role "${role}" must have the following attributes defined: ${requiredProps}`,
-    type: 'JSXAttribute',
   };
 };
 

--- a/__tests__/src/rules/role-supports-aria-props.spec.js
+++ b/__tests__/src/rules/role-supports-aria-props.spec.js
@@ -32,7 +32,6 @@ const generateErrorMessage = (attr, role, tag, isImplicit) => {
 
 const errorMessage = (attr, role, tag, isImplicit) => ({
   message: generateErrorMessage(attr, role, tag, isImplicit),
-  type: 'JSXOpeningElement',
 });
 
 const componentsSettings = {

--- a/__tests__/src/rules/scope.spec.js
+++ b/__tests__/src/rules/scope.spec.js
@@ -20,7 +20,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message: 'The scope prop can only be used on <th> elements.',
-  type: 'JSXAttribute',
 };
 
 const componentsSettings = {

--- a/__tests__/src/rules/tabindex-no-positive.spec.js
+++ b/__tests__/src/rules/tabindex-no-positive.spec.js
@@ -20,7 +20,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message: 'Avoid positive integer values for tabIndex.',
-  type: 'JSXAttribute',
 };
 
 ruleTester.run('tabindex-no-positive', rule, {

--- a/scripts/boilerplate/test.cjs
+++ b/scripts/boilerplate/test.cjs
@@ -20,7 +20,6 @@ const ruleTester = new RuleTester();
 
 const expectedError = {
   message: '',
-  type: 'JSXOpeningElement',
 };
 
 ruleTester.run('${name}', rule, {


### PR DESCRIPTION
Per the rule-tester code,

https://github.com/eslint/eslint/blob/7f479376a2fa463d823ab762db6bb37ce8d2ee8f/lib/rule-tester/rule-tester.js#L124-L133

The only allowed attributes in an invalid case are:

- message
- messageId
- data
- line
- column
- endLine
- endColumn
- suggestions

Notice, that "type" is not included, so it has been removed.

This discrepancy was noticed when attempting to upgrade to eslint 10, which throws an error on invalid attributes passed to rule tester. This kind of error will likely be caught by TypeScript once integrated.