### PR TITLE
Remove the "errors" property from valid tests cases

### DIFF
--- a/__tests__/src/rules/aria-unsupported-elements.spec.js
+++ b/__tests__/src/rules/aria-unsupported-elements.spec.js
@@ -47,7 +47,6 @@ const ariaValidityTests = domElements
   })
   .concat({
     code: '<fake aria-hidden />',
-    errors: [errorMessage('aria-hidden')],
   });
 
 // Generate invalid test cases.

--- a/__tests__/src/rules/autocomplete-valid.spec.js
+++ b/__tests__/src/rules/autocomplete-valid.spec.js
@@ -25,12 +25,6 @@ const invalidAutocomplete = [
   },
 ];
 
-const inappropriateAutocomplete = [
-  {
-    message: axeFailMessage('autocomplete-appropriate'),
-  },
-];
-
 const componentsSettings = {
   'jsx-a11y-x': {
     components: {
@@ -74,19 +68,15 @@ ruleTester.run('autocomplete-valid', rule, {
       // see also: https://github.com/dequelabs/axe-core/issues/2912
       {
         code: '<input type="date" autocomplete="email" />;',
-        errors: inappropriateAutocomplete,
       },
       {
         code: '<input type="number" autocomplete="url" />;',
-        errors: inappropriateAutocomplete,
       },
       {
         code: '<input type="month" autocomplete="tel" />;',
-        errors: inappropriateAutocomplete,
       },
       {
         code: '<Foo type="month" autocomplete="tel"></Foo>;',
-        errors: inappropriateAutocomplete,
         options: [{ inputComponents: ['Foo'] }],
       },
     ])

--- a/__tests__/src/rules/html-has-lang.spec.js
+++ b/__tests__/src/rules/html-has-lang.spec.js
@@ -33,7 +33,6 @@ ruleTester.run('html-has-lang', rule, {
       { code: '<HTML />' },
       {
         code: '<HTMLTop lang="en" />',
-        errors: [expectedError],
         settings: { 'jsx-a11y-x': { components: { HTMLTop: 'html' } } },
       },
     ])

--- a/__tests__/src/rules/no-noninteractive-tabindex.spec.js
+++ b/__tests__/src/rules/no-noninteractive-tabindex.spec.js
@@ -86,12 +86,10 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
       {
         code: '<div role={isButton ? "button" : LINK} onClick={() => {}} tabIndex="0" />;',
         options: [{ allowExpressionValues: true }],
-        errors: [expectedError],
       },
       {
         code: '<div role={isButton ? BUTTON : LINK} onClick={() => {}} tabIndex="0"/>;',
         options: [{ allowExpressionValues: true }],
-        errors: [expectedError],
       },
     ])
     .map(ruleOptionsMapperFactory(recommendedOptions))

--- a/__tests__/src/rules/no-static-element-interactions.spec.js
+++ b/__tests__/src/rules/no-static-element-interactions.spec.js
@@ -464,12 +464,10 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
       {
         code: '<div role={isButton ? "button" : LINK} onClick={() => {}} />;',
         options: [{ allowExpressionValues: true }],
-        errors: [expectedError],
       },
       {
         code: '<div role={isButton ? BUTTON : LINK} onClick={() => {}} />;',
         options: [{ allowExpressionValues: true }],
-        errors: [expectedError],
       },
     ])
     .map(ruleOptionsMapperFactory(recommendedOptions))


### PR DESCRIPTION
Per the rule-tester code, it does not allow the "errors" property on valid cases. See the line:

https://github.com/eslint/eslint/blob/7f479376a2fa463d823ab762db6bb37ce8d2ee8f/lib/rule-tester/rule-tester.js#L614

Starting with eslint 10, when this property exists, rule-tester raises the error: `Valid test case must not have 'errors' property`.

This discrepancy was noticed by attempting to upgrade to eslint 10 and analyzing the new test failures.