### PR TITLE
Remove another instance of the `[].concat` pattern

### DIFF
--- a/src/rules/alt-text.js
+++ b/src/rules/alt-text.js
@@ -224,9 +224,9 @@ export default {
       (element) => options[element],
     );
     const typesToValidate = new Set(
-      []
-        .concat(customComponents, elementOptions)
-        .map((type) => (type === 'input[type="image"]' ? 'input' : type)),
+      [...customComponents, ...elementOptions].map((type) =>
+        type === 'input[type="image"]' ? 'input' : type,
+      ),
     );
     const elementType = getElementType(context);
 


### PR DESCRIPTION
This instance was missed in 529493229825f25bc67b35f26b00c719dc739cbb.