### PR TITLE
Replace `for (let i = 0; ...` pattern with `for (const ... of`

### DIFF
--- a/__tests__/index.spec.js
+++ b/__tests__/index.spec.js
@@ -36,9 +36,7 @@ test('schemas', async () => {
 });
 
 test('plugin referentially equal to prevent flat config issues', () => {
-  const keys = Object.keys(plugin.flatConfigs);
-  for (let i = 0; i < keys.length; i += 1) {
-    const config = plugin.flatConfigs[keys[i]];
+  for (const config of Object.values(plugin.flatConfigs)) {
     expect(plugin).toBe(config.plugins['jsx-a11y-x']);
   }
 });

--- a/src/rules/label-has-associated-control.js
+++ b/src/rules/label-has-associated-control.js
@@ -48,8 +48,7 @@ const validateHtmlFor = (node, context) => {
     'htmlFor',
   ];
 
-  for (let i = 0; i < htmlForAttributes.length; i += 1) {
-    const attribute = htmlForAttributes[i];
+  for (const attribute of htmlForAttributes) {
     if (hasProp(node.attributes, attribute)) {
       const htmlForAttr = getProp(node.attributes, attribute);
       const htmlForValue = getPropValue(htmlForAttr);

--- a/src/util/mayContainChildComponent.js
+++ b/src/util/mayContainChildComponent.js
@@ -22,8 +22,7 @@ export default function mayContainChildComponent(
       return false;
     }
     if (node.children) {
-      for (let i = 0; i < node.children.length; i += 1) {
-        const childNode = node.children[i];
+      for (const childNode of node.children) {
         // Assume an expression container renders a label. It is the best we can
         // do in this case.
         if (childNode.type === 'JSXExpressionContainer') {

--- a/src/util/mayHaveAccessibleLabel.js
+++ b/src/util/mayHaveAccessibleLabel.js
@@ -89,8 +89,8 @@ export default function mayHaveAccessibleLabel(
 
     // Recurse into the child element nodes.
     if (node.children) {
-      for (let i = 0; i < node.children.length; i += 1) {
-        if (checkElement(node.children[i], depth + 1)) {
+      for (const childNode of node.children) {
+        if (checkElement(childNode, depth + 1)) {
           return true;
         }
       }


### PR DESCRIPTION
Modern Node.js and JavaScript support iterating iterables with the builtin syntax `for (const x of ...)`.

The new syntax also improves type-checking when introducing TypeScript as there is no indexing involved, which (depending on strictness) can return undefined.