### PR TITLE
Remove unnecessary fallback for options in rules

### DIFF
--- a/src/rules/alt-text.js
+++ b/src/rules/alt-text.js
@@ -216,7 +216,7 @@ export default {
   },
 
   create: (context) => {
-    const options = context.options[0] || {};
+    const options = context.options[0];
     // Elements to validate for alt text.
     const elementOptions = options.elements;
     // Get custom components for just the elements that will be tested.

--- a/src/rules/anchor-ambiguous-text.js
+++ b/src/rules/anchor-ambiguous-text.js
@@ -40,7 +40,7 @@ export default {
 
     const typesToValidate = ['a'];
 
-    const options = context.options[0] || {};
+    const options = context.options[0];
     const { words } = options;
     const ambiguousWords = new Set(words);
 

--- a/src/rules/anchor-has-content.js
+++ b/src/rules/anchor-has-content.js
@@ -34,7 +34,7 @@ export default {
     const elementType = getElementType(context);
     return {
       JSXOpeningElement: (node) => {
-        const options = context.options[0] || {};
+        const options = context.options[0];
         const componentOptions = options.components;
         const typeCheck = ['a'].concat(componentOptions);
         const nodeType = elementType(node);

--- a/src/rules/anchor-is-valid.js
+++ b/src/rules/anchor-is-valid.js
@@ -52,7 +52,7 @@ export default {
     return {
       JSXOpeningElement: (node) => {
         const { attributes } = node;
-        const options = context.options[0] || {};
+        const options = context.options[0];
         const componentOptions = options.components;
         const typeCheck = ['a'].concat(componentOptions);
         const nodeType = elementType(node);

--- a/src/rules/aria-role.js
+++ b/src/rules/aria-role.js
@@ -47,7 +47,7 @@ export default {
   },
 
   create: (context) => {
-    const options = context.options[0] || {};
+    const options = context.options[0];
     const ignoreNonDOM = options.ignoreNonDOM;
     const allowedInvalidRoles = new Set(options.allowedInvalidRoles);
     const elementType = getElementType(context);

--- a/src/rules/autocomplete-valid.js
+++ b/src/rules/autocomplete-valid.js
@@ -32,7 +32,7 @@ export default {
     const elementType = getElementType(context);
     return {
       JSXOpeningElement: (node) => {
-        const options = context.options[0] || {};
+        const options = context.options[0];
         const { inputComponents } = options;
         const inputTypes = ['input'].concat(inputComponents);
 

--- a/src/rules/control-has-associated-label.js
+++ b/src/rules/control-has-associated-label.js
@@ -54,7 +54,7 @@ export default {
 
   create: (context) => {
     const elementType = getElementType(context);
-    const options = context.options[0] || {};
+    const options = context.options[0];
     const { labelAttributes, controlComponents, ignoreElements, ignoreRoles } =
       options;
 

--- a/src/rules/heading-has-content.js
+++ b/src/rules/heading-has-content.js
@@ -34,7 +34,7 @@ export default {
     const elementType = getElementType(context);
     return {
       JSXOpeningElement: (node) => {
-        const options = context.options[0] || {};
+        const options = context.options[0];
         const componentOptions = options.components;
         const typeCheck = headings.concat(componentOptions);
         const nodeType = elementType(node);

--- a/src/rules/img-redundant-alt.js
+++ b/src/rules/img-redundant-alt.js
@@ -59,7 +59,7 @@ export default {
     const elementType = getElementType(context);
     return {
       JSXOpeningElement: (node) => {
-        const options = context.options[0] || {};
+        const options = context.options[0];
         const componentOptions = options.components;
         const typesToValidate = ['img'].concat(componentOptions);
         const nodeType = elementType(node);

--- a/src/rules/interactive-supports-focus.js
+++ b/src/rules/interactive-supports-focus.js
@@ -64,8 +64,7 @@ export default {
     const elementType = getElementType(context);
     return {
       JSXOpeningElement: (node) => {
-        const tabbable =
-          context.options && context.options[0] && context.options[0].tabbable;
+        const { tabbable } = context.options[0];
         const { attributes } = node;
         const type = elementType(node);
         const hasInteractiveProps = hasAnyProp(attributes, interactiveProps);

--- a/src/rules/label-has-associated-control.js
+++ b/src/rules/label-has-associated-control.js
@@ -81,7 +81,7 @@ export default {
   },
 
   create: (context) => {
-    const options = context.options[0] || {};
+    const options = context.options[0];
     const labelComponents = options.labelComponents;
     const assertType = options.assert;
     const labelComponentNames = ['label'].concat(labelComponents);

--- a/src/rules/media-has-caption.js
+++ b/src/rules/media-has-caption.js
@@ -25,14 +25,14 @@ const schema = generateObjSchema({
 });
 
 const isMediaType = (context, type) => {
-  const options = context.options[0] || {};
+  const options = context.options[0];
   return MEDIA_TYPES.concat(
     MEDIA_TYPES.flatMap((mediaType) => options[mediaType]),
   ).some((typeToCheck) => typeToCheck === type);
 };
 
 const isTrackType = (context, type) => {
-  const options = context.options[0] || {};
+  const options = context.options[0];
   return ['track']
     .concat(options.track)
     .some((typeToCheck) => typeToCheck === type);

--- a/src/rules/mouse-events-have-key-events.js
+++ b/src/rules/mouse-events-have-key-events.js
@@ -54,10 +54,7 @@ export default {
       }
 
       const { options } = context;
-
-      const hoverInHandlers = options[0]?.hoverInHandlers;
-      const hoverOutHandlers = options[0]?.hoverOutHandlers;
-
+      const { hoverInHandlers, hoverOutHandlers } = options[0];
       const { attributes } = node;
 
       // Check hover in / onfocus pairing

--- a/src/rules/no-autofocus.js
+++ b/src/rules/no-autofocus.js
@@ -39,7 +39,7 @@ export default {
       JSXAttribute: (attribute) => {
         // Determine if ignoreNonDOM is set to true
         // If true, then do not run rule.
-        const options = context.options[0] || {};
+        const options = context.options[0];
         const ignoreNonDOM = options.ignoreNonDOM;
 
         if (ignoreNonDOM) {

--- a/src/rules/no-distracting-elements.js
+++ b/src/rules/no-distracting-elements.js
@@ -33,7 +33,7 @@ export default {
     const elementType = getElementType(context);
     return {
       JSXOpeningElement: (node) => {
-        const options = context.options[0] || {};
+        const options = context.options[0];
         const elementOptions = options.elements;
         const type = elementType(node);
         const distractingElement = elementOptions.find(

--- a/src/rules/no-interactive-element-to-noninteractive-role.js
+++ b/src/rules/no-interactive-element-to-noninteractive-role.js
@@ -65,7 +65,7 @@ export default {
         }
         // Allow overrides from rule configuration for specific elements and
         // roles.
-        const allowedRoles = options[0] || {};
+        const allowedRoles = options[0];
         if (
           Object.hasOwn(allowedRoles, type) &&
           allowedRoles[type].includes(role)

--- a/src/rules/no-noninteractive-element-interactions.js
+++ b/src/rules/no-noninteractive-element-interactions.js
@@ -53,7 +53,7 @@ export default {
       JSXOpeningElement: (node) => {
         let { attributes } = node;
         const type = elementType(node);
-        const config = options[0] || {};
+        const config = options[0];
         const interactiveProps = config.handlers || defaultInteractiveProps;
         // Allow overrides from rule configuration for specific elements and roles.
         if (Object.hasOwn(config, type)) {

--- a/src/rules/no-noninteractive-element-to-interactive-role.js
+++ b/src/rules/no-noninteractive-element-to-interactive-role.js
@@ -65,7 +65,7 @@ export default {
         }
         // Allow overrides from rule configuration for specific elements and
         // roles.
-        const allowedRoles = options[0] || {};
+        const allowedRoles = options[0];
         if (
           Object.hasOwn(allowedRoles, type) &&
           allowedRoles[type].includes(role)

--- a/src/rules/no-noninteractive-tabindex.js
+++ b/src/rules/no-noninteractive-tabindex.js
@@ -64,7 +64,7 @@ export default {
           return;
         }
         // Allow for configuration overrides.
-        const { tags, roles, allowExpressionValues } = options[0] || {};
+        const { tags, roles, allowExpressionValues } = options[0];
         if (tags.includes(type)) {
           return;
         }

--- a/src/rules/no-redundant-roles.js
+++ b/src/rules/no-redundant-roles.js
@@ -55,7 +55,7 @@ export default {
         }
 
         if (implicitRole === explicitRole) {
-          const allowedRedundantRoles = options[0] || {};
+          const allowedRedundantRoles = options[0];
           let redundantRolesForElement;
 
           if (Object.hasOwn(allowedRedundantRoles, type)) {

--- a/src/rules/no-static-element-interactions.js
+++ b/src/rules/no-static-element-interactions.js
@@ -53,7 +53,7 @@ export default {
         const { attributes } = node;
         const type = elementType(node);
 
-        const { allowExpressionValues, handlers } = options[0] || {};
+        const { allowExpressionValues, handlers } = options[0];
 
         const hasInteractiveProps = handlers.some(
           (prop) =>


### PR DESCRIPTION
Rule options always fallback to the default options defined in the rule's meta. So adding another fallback in the rule code is unnecessary. This change slightly simplifies the rule code.