### PR TITLE
Remove support for deprecated "babel-eslint" from the test suite

### DIFF
--- a/__tests__/__util__/helpers/parsers.js
+++ b/__tests__/__util__/helpers/parsers.js
@@ -43,7 +43,6 @@ function minEcmaVersion(features, parserOptions) {
 const NODE_MODULES = '../../node_modules';
 
 const parsers = {
-  BABEL_ESLINT: path.join(__dirname, NODE_MODULES, 'babel-eslint'),
   '@BABEL_ESLINT': path.join(__dirname, NODE_MODULES, '@babel/eslint-parser'),
   TYPESCRIPT_ESLINT: path.join(
     __dirname,
@@ -157,11 +156,6 @@ const parsers = {
         (features.has('fragment') && semver.satisfies(version, '< 5'));
 
       const skipBabel = features.has('no-babel');
-      const skipOldBabel =
-        skipBabel ||
-        features.has('no-babel-old') ||
-        features.has('optional chaining') ||
-        semver.satisfies(version, '>= 8');
       const skipNewBabel =
         skipBabel ||
         features.has('no-babel-new') ||
@@ -189,19 +183,6 @@ const parsers = {
               }),
             },
             'default',
-          ),
-        );
-      }
-
-      if (!skipOldBabel) {
-        testObjects.pushs(
-          addComment(
-            {
-              ...test,
-              parser: parsers.BABEL_ESLINT,
-              parserOptions: parsers.babelParserOptions(test, features),
-            },
-            'babel-eslint',
           ),
         );
       }


### PR DESCRIPTION
The babel-eslint package has been unused since
aed7a20f34e886edb27550e766cc89f662e915ba.

Additionally the "babel-eslint" package has been deprecated by its maintainers, see https://www.npmjs.com/package/babel-eslint. It has not had a published release in over 6 years.