### PR TITLE
Simplify parsers.js to test a consistent set of parsers on every run

### DIFF
--- a/__tests__/__util__/helpers/parsers.js
+++ b/__tests__/__util__/helpers/parsers.js
@@ -1,90 +1,39 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { ESLint } from 'eslint';
-import semver from 'semver';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const version = ESLint.version;
 
-function minEcmaVersion(features, parserOptions) {
-  const minEcmaVersionForFeatures = {
-    'class fields': 2022,
-    'optional chaining': 2020,
-    'nullish coalescing': 2020,
+function babelParserOptions(test) {
+  return {
+    ...test.parserOptions,
+    requireConfigFile: false,
+    babelOptions: {
+      presets: ['@babel/preset-react'],
+      plugins: [
+        '@babel/plugin-syntax-do-expressions',
+        '@babel/plugin-syntax-function-bind',
+        ['@babel/plugin-syntax-decorators', { legacy: true }],
+      ],
+      parserOpts: {
+        allowSuperOutsideMethod: false,
+        allowReturnOutsideFunction: false,
+      },
+    },
+    ecmaFeatures: {
+      ...(test.parserOptions && test.parserOptions.ecmaFeatures),
+      jsx: true,
+      modules: true,
+    },
   };
-  const result = Math.max(
-    ...[]
-      .concat(
-        (parserOptions && parserOptions.ecmaVersion) || [],
-        Object.entries(minEcmaVersionForFeatures).flatMap((entry) => {
-          const f = entry[0];
-          const y = entry[1];
-          return features.has(f) ? y : [];
-        }),
-      )
-      .map((y) => (y > 5 && y < 2015 ? y + 2009 : y)), // normalize editions to years
-  );
-  return Number.isFinite(result) ? result : undefined;
 }
 
 const NODE_MODULES = '../../node_modules';
 
 const parsers = {
-  '@BABEL_ESLINT': path.join(__dirname, NODE_MODULES, '@babel/eslint-parser'),
-  TYPESCRIPT_ESLINT: path.join(
-    __dirname,
-    NODE_MODULES,
-    'typescript-eslint-parser',
-  ),
-  '@TYPESCRIPT_ESLINT': path.join(
-    __dirname,
-    NODE_MODULES,
-    '@typescript-eslint/parser',
-  ),
-  babelParserOptions: function parserOptions(test, features) {
-    return {
-      ...test.parserOptions,
-      requireConfigFile: false,
-      babelOptions: {
-        presets: ['@babel/preset-react'],
-        plugins: [
-          '@babel/plugin-syntax-do-expressions',
-          '@babel/plugin-syntax-function-bind',
-          ['@babel/plugin-syntax-decorators', { legacy: true }],
-        ],
-        parserOpts: {
-          allowSuperOutsideMethod: false,
-          allowReturnOutsideFunction: false,
-        },
-      },
-      ecmaFeatures: {
-        ...(test.parserOptions && test.parserOptions.ecmaFeatures),
-        jsx: true,
-        modules: true,
-        legacyDecorators: features.has('decorators'),
-      },
-    };
-  },
   all: function all(tests) {
     const t = tests.flatMap((test) => {
-      /* eslint no-param-reassign: 0 */
-      if (typeof test === 'string') {
-        test = { code: test };
-      }
-      if ('parser' in test) {
-        delete test.features;
-        return test;
-      }
-      const features = new Set(test.features);
-      delete test.features;
-
-      const es = minEcmaVersion(features, test.parserOptions);
-
       function addComment(testObject, parser) {
-        const extras = [
-          `features: [${Array.from(features).join(',')}]`,
-          `parser: ${parser}`,
-        ];
+        const extras = [`parser: ${parser}`];
         if (testObject.parserOptions) {
           extras.push(
             `parserOptions: ${JSON.stringify(testObject.parserOptions)}`,
@@ -130,79 +79,34 @@ const parsers = {
         };
       }
 
-      const skipBase =
-        (features.has('class fields') && semver.satisfies(version, '< 8')) ||
-        (es >= 2020 && semver.satisfies(version, '< 6')) ||
-        features.has('no-default') ||
-        features.has('bind operator') ||
-        features.has('do expressions') ||
-        features.has('decorators') ||
-        features.has('ts') ||
-        features.has('types') ||
-        (features.has('fragment') && semver.satisfies(version, '< 5'));
-
-      const skipBabel = features.has('no-babel');
-      const skipNewBabel =
-        skipBabel ||
-        features.has('no-babel-new') ||
-        !semver.satisfies(version, '^7.5.0') || // require('@babel/eslint-parser/package.json').peerDependencies.eslint
-        features.has('types') ||
-        features.has('ts');
-      const skipTS =
-        semver.satisfies(version, '<= 5') || // TODO: make these pass on eslint 5
-        features.has('no-ts') ||
-        features.has('jsx namespace') ||
-        features.has('bind operator') ||
-        features.has('do expressions');
-      const tsOld = !skipTS && !features.has('no-ts-old');
-      const tsNew = !skipTS && !features.has('no-ts-new');
-
       const testObjects = [];
 
-      if (!skipBase) {
-        testObjects.push(
-          addComment(
-            {
-              ...test,
-              ...(typeof es === 'number' && {
-                parserOptions: { ...test.parserOptions, ecmaVersion: es },
-              }),
-            },
-            'default',
-          ),
-        );
-      }
+      testObjects.push(addComment({ ...test }, 'default'));
 
-      if (!skipNewBabel) {
-        testObjects.push(
-          addComment(
-            {
-              ...test,
-              parser: parsers['@BABEL_ESLINT'],
-              parserOptions: parsers.babelParserOptions(test, features),
-            },
-            '@babel/eslint-parser',
-          ),
-        );
-      }
+      testObjects.push(
+        addComment(
+          {
+            ...test,
+            parser: path.join(__dirname, NODE_MODULES, '@babel/eslint-parser'),
+            parserOptions: babelParserOptions(test),
+          },
+          '@babel/eslint-parser',
+        ),
+      );
 
-      if (tsOld) {
-        testObjects.push(
-          addComment(
-            { ...test, parser: parsers.TYPESCRIPT_ESLINT },
-            'typescript-eslint',
-          ),
-        );
-      }
-
-      if (tsNew) {
-        testObjects.push(
-          addComment(
-            { ...test, parser: parsers['@TYPESCRIPT_ESLINT'] },
-            '@typescript-eslint/parser',
-          ),
-        );
-      }
+      testObjects.push(
+        addComment(
+          {
+            ...test,
+            parser: path.join(
+              __dirname,
+              NODE_MODULES,
+              '@typescript-eslint/parser',
+            ),
+          },
+          '@typescript-eslint/parser',
+        ),
+      );
 
       return testObjects;
     });

--- a/package.json
+++ b/package.json
@@ -55,9 +55,11 @@
     "minimatch": "^10.2.5"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.28.6",
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.29.4",
     "@eslint/js": "^10.0.1",
+    "@typescript-eslint/parser": "^8.59.0",
     "@vitest/coverage-v8": "^4.1.4",
     "clean-pkg-json": "^1.3.0",
     "eslint": "^10.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: ^10.2.5
         version: 10.2.5
     devDependencies:
+      '@babel/eslint-parser':
+        specifier: ^7.28.6
+        version: 7.28.6(@babel/core@7.29.0)(eslint@10.2.1)
       '@changesets/changelog-github':
         specifier: ^0.5.1
         version: 0.5.2
@@ -39,6 +42,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.1)
+      '@typescript-eslint/parser':
+        specifier: ^8.59.0
+        version: 8.59.0(eslint@10.2.1)(typescript@6.0.2)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
@@ -95,6 +101,13 @@ packages:
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/eslint-parser@7.28.6':
+    resolution: {integrity: sha512-QGmsKi2PBO/MHSQk+AAgA9R6OHQr+VqnniFE0eMWZcVcfBZoA2dKn2hUsl3Csg/Plt9opRUWdY7//VXsrIlEiA==}
+    engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
+    peerDependencies:
+      '@babel/core': ^7.11.0
+      eslint: ^7.5.0 || ^8.0.0 || ^9.0.0
 
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
@@ -958,6 +971,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
+    resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1148,8 +1164,21 @@ packages:
   '@types/node@25.5.2':
     resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
+  '@typescript-eslint/parser@8.59.0':
+    resolution: {integrity: sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/project-service@8.58.0':
     resolution: {integrity: sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.0':
+    resolution: {integrity: sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1158,8 +1187,18 @@ packages:
     resolution: {integrity: sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.59.0':
+    resolution: {integrity: sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/tsconfig-utils@8.58.0':
     resolution: {integrity: sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/tsconfig-utils@8.59.0':
+    resolution: {integrity: sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1168,8 +1207,18 @@ packages:
     resolution: {integrity: sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.59.0':
+    resolution: {integrity: sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.58.0':
     resolution: {integrity: sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/typescript-estree@8.59.0':
+    resolution: {integrity: sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
@@ -1183,6 +1232,10 @@ packages:
 
   '@typescript-eslint/visitor-keys@8.58.0':
     resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -1644,9 +1697,17 @@ packages:
       eslint-import-resolver-node:
         optional: true
 
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
   eslint-scope@9.1.2:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@2.1.0:
+    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
+    engines: {node: '>=10'}
 
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
@@ -1686,6 +1747,10 @@ packages:
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
@@ -2609,6 +2674,14 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@10.2.1)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
+      eslint: 10.2.1
+      eslint-visitor-keys: 2.1.0
+      semver: 6.3.1
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -3712,6 +3785,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
+    dependencies:
+      eslint-scope: 5.1.1
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3834,10 +3911,31 @@ snapshots:
       undici-types: 7.18.2
     optional: true
 
+  '@typescript-eslint/parser@8.59.0(eslint@10.2.1)(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.0
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/typescript-estree': 8.59.0(typescript@6.0.2)
+      '@typescript-eslint/visitor-keys': 8.59.0
+      debug: 4.4.3
+      eslint: 10.2.1
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/project-service@8.58.0(typescript@6.0.2)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.0
+      debug: 4.4.3
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.0(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.2)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -3848,11 +3946,22 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/visitor-keys': 8.58.0
 
+  '@typescript-eslint/scope-manager@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
+
   '@typescript-eslint/tsconfig-utils@8.58.0(typescript@6.0.2)':
     dependencies:
       typescript: 6.0.2
 
+  '@typescript-eslint/tsconfig-utils@8.59.0(typescript@6.0.2)':
+    dependencies:
+      typescript: 6.0.2
+
   '@typescript-eslint/types@8.58.0': {}
+
+  '@typescript-eslint/types@8.59.0': {}
 
   '@typescript-eslint/typescript-estree@8.58.0(typescript@6.0.2)':
     dependencies:
@@ -3860,6 +3969,21 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/visitor-keys': 8.58.0
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/typescript-estree@8.59.0(typescript@6.0.2)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.0(typescript@6.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.2)
+      '@typescript-eslint/types': 8.59.0
+      '@typescript-eslint/visitor-keys': 8.59.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
@@ -3883,6 +4007,11 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.58.0':
     dependencies:
       '@typescript-eslint/types': 8.58.0
+      eslint-visitor-keys: 5.0.1
+
+  '@typescript-eslint/visitor-keys@8.59.0':
+    dependencies:
+      '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
@@ -4324,12 +4453,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
       '@types/estree': 1.0.8
       esrecurse: 4.3.0
       estraverse: 5.3.0
+
+  eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.3: {}
 
@@ -4387,6 +4523,8 @@ snapshots:
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
 


### PR DESCRIPTION
The parsers.js test configuration file had accumulated conditional logic that would sometimes include a parser and sometimes not, depending on various conditions. Some of this logic was dead code and other parts were more complex than the problem warranted.

The file has been simplified to always test the same three parsers on every run: ESLint default, babel/eslint-parser, and typescript-eslint/parser. If these parsers are worth testing at all, they are worth testing consistently rather than conditionally.