### PR TITLE
Precise the return type of functions in src/util/implicitRoles/*

### DIFF
--- a/src/util/implicitRoles/article.ts
+++ b/src/util/implicitRoles/article.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an article tag. */
-export default function getImplicitRoleForArticle() {
+export default function getImplicitRoleForArticle(): ARIARoleDefinitionKey {
   return 'article';
 }

--- a/src/util/implicitRoles/aside.ts
+++ b/src/util/implicitRoles/aside.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an aside tag. */
-export default function getImplicitRoleForAside() {
+export default function getImplicitRoleForAside(): ARIARoleDefinitionKey {
   return 'complementary';
 }

--- a/src/util/implicitRoles/body.ts
+++ b/src/util/implicitRoles/body.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a body tag. */
-export default function getImplicitRoleForBody() {
+export default function getImplicitRoleForBody(): ARIARoleDefinitionKey {
   return 'document';
 }

--- a/src/util/implicitRoles/button.ts
+++ b/src/util/implicitRoles/button.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from "aria-query";
+
 /** Returns the implicit role for a button tag. */
-export default function getImplicitRoleForButton() {
+export default function getImplicitRoleForButton(): ARIARoleDefinitionKey {
   return 'button';
 }

--- a/src/util/implicitRoles/button.ts
+++ b/src/util/implicitRoles/button.ts
@@ -1,4 +1,4 @@
-import type { ARIARoleDefinitionKey } from "aria-query";
+import type { ARIARoleDefinitionKey } from 'aria-query';
 
 /** Returns the implicit role for a button tag. */
 export default function getImplicitRoleForButton(): ARIARoleDefinitionKey {

--- a/src/util/implicitRoles/datalist.ts
+++ b/src/util/implicitRoles/datalist.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a datalist tag. */
-export default function getImplicitRoleForDatalist() {
+export default function getImplicitRoleForDatalist(): ARIARoleDefinitionKey {
   return 'listbox';
 }

--- a/src/util/implicitRoles/details.ts
+++ b/src/util/implicitRoles/details.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a details tag. */
-export default function getImplicitRoleForDetails() {
+export default function getImplicitRoleForDetails(): ARIARoleDefinitionKey {
   return 'group';
 }

--- a/src/util/implicitRoles/dialog.ts
+++ b/src/util/implicitRoles/dialog.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a dialog tag. */
-export default function getImplicitRoleForDialog() {
+export default function getImplicitRoleForDialog(): ARIARoleDefinitionKey {
   return 'dialog';
 }

--- a/src/util/implicitRoles/form.ts
+++ b/src/util/implicitRoles/form.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a form tag. */
-export default function getImplicitRoleForForm() {
+export default function getImplicitRoleForForm(): ARIARoleDefinitionKey {
   return 'form';
 }

--- a/src/util/implicitRoles/h1.ts
+++ b/src/util/implicitRoles/h1.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an h1 tag. */
-export default function getImplicitRoleForH1() {
+export default function getImplicitRoleForH1(): ARIARoleDefinitionKey {
   return 'heading';
 }

--- a/src/util/implicitRoles/h2.ts
+++ b/src/util/implicitRoles/h2.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an h2 tag. */
-export default function getImplicitRoleForH2() {
+export default function getImplicitRoleForH2(): ARIARoleDefinitionKey {
   return 'heading';
 }

--- a/src/util/implicitRoles/h3.ts
+++ b/src/util/implicitRoles/h3.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an h3 tag. */
-export default function getImplicitRoleForH3() {
+export default function getImplicitRoleForH3(): ARIARoleDefinitionKey {
   return 'heading';
 }

--- a/src/util/implicitRoles/h4.ts
+++ b/src/util/implicitRoles/h4.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an h4 tag. */
-export default function getImplicitRoleForH4() {
+export default function getImplicitRoleForH4(): ARIARoleDefinitionKey {
   return 'heading';
 }

--- a/src/util/implicitRoles/h5.ts
+++ b/src/util/implicitRoles/h5.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an h5 tag. */
-export default function getImplicitRoleForH5() {
+export default function getImplicitRoleForH5(): ARIARoleDefinitionKey {
   return 'heading';
 }

--- a/src/util/implicitRoles/h6.ts
+++ b/src/util/implicitRoles/h6.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an h6tag. */
-export default function getImplicitRoleForH6() {
+export default function getImplicitRoleForH6(): ARIARoleDefinitionKey {
   return 'heading';
 }

--- a/src/util/implicitRoles/hr.ts
+++ b/src/util/implicitRoles/hr.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an hr tag. */
-export default function getImplicitRoleForHr() {
+export default function getImplicitRoleForHr(): ARIARoleDefinitionKey {
   return 'separator';
 }

--- a/src/util/implicitRoles/li.ts
+++ b/src/util/implicitRoles/li.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an li tag. */
-export default function getImplicitRoleForLi() {
+export default function getImplicitRoleForLi(): ARIARoleDefinitionKey {
   return 'listitem';
 }

--- a/src/util/implicitRoles/meter.ts
+++ b/src/util/implicitRoles/meter.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a meter tag. */
-export default function getImplicitRoleForMeter() {
+export default function getImplicitRoleForMeter(): ARIARoleDefinitionKey {
   return 'progressbar';
 }

--- a/src/util/implicitRoles/nav.ts
+++ b/src/util/implicitRoles/nav.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a nav tag. */
-export default function getImplicitRoleForNav() {
+export default function getImplicitRoleForNav(): ARIARoleDefinitionKey {
   return 'navigation';
 }

--- a/src/util/implicitRoles/ol.ts
+++ b/src/util/implicitRoles/ol.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an ol tag. */
-export default function getImplicitRoleForOl() {
+export default function getImplicitRoleForOl(): ARIARoleDefinitionKey {
   return 'list';
 }

--- a/src/util/implicitRoles/option.ts
+++ b/src/util/implicitRoles/option.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an option tag. */
-export default function getImplicitRoleForOption() {
+export default function getImplicitRoleForOption(): ARIARoleDefinitionKey {
   return 'option';
 }

--- a/src/util/implicitRoles/output.ts
+++ b/src/util/implicitRoles/output.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for an output tag. */
-export default function getImplicitRoleForOutput() {
+export default function getImplicitRoleForOutput(): ARIARoleDefinitionKey {
   return 'status';
 }

--- a/src/util/implicitRoles/progress.ts
+++ b/src/util/implicitRoles/progress.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a progress tag. */
-export default function getImplicitRoleForProgress() {
+export default function getImplicitRoleForProgress(): ARIARoleDefinitionKey {
   return 'progressbar';
 }

--- a/src/util/implicitRoles/section.ts
+++ b/src/util/implicitRoles/section.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a section tag. */
-export default function getImplicitRoleForSection() {
+export default function getImplicitRoleForSection(): ARIARoleDefinitionKey {
   return 'region';
 }

--- a/src/util/implicitRoles/tbody.ts
+++ b/src/util/implicitRoles/tbody.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a tbody tag. */
-export default function getImplicitRoleForTbody() {
+export default function getImplicitRoleForTbody(): ARIARoleDefinitionKey {
   return 'rowgroup';
 }

--- a/src/util/implicitRoles/textarea.ts
+++ b/src/util/implicitRoles/textarea.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a textarea tag. */
-export default function getImplicitRoleForTextarea() {
+export default function getImplicitRoleForTextarea(): ARIARoleDefinitionKey {
   return 'textbox';
 }

--- a/src/util/implicitRoles/tfoot.ts
+++ b/src/util/implicitRoles/tfoot.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a tfoot tag. */
-export default function getImplicitRoleForTfoot() {
+export default function getImplicitRoleForTfoot(): ARIARoleDefinitionKey {
   return 'rowgroup';
 }

--- a/src/util/implicitRoles/thead.ts
+++ b/src/util/implicitRoles/thead.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a thead tag. */
-export default function getImplicitRoleForThead() {
+export default function getImplicitRoleForThead(): ARIARoleDefinitionKey {
   return 'rowgroup';
 }

--- a/src/util/implicitRoles/ul.ts
+++ b/src/util/implicitRoles/ul.ts
@@ -1,4 +1,6 @@
+import type { ARIARoleDefinitionKey } from 'aria-query';
+
 /** Returns the implicit role for a ul tag. */
-export default function getImplicitRoleForUl() {
+export default function getImplicitRoleForUl(): ARIARoleDefinitionKey {
   return 'list';
 }


### PR DESCRIPTION
This change establishes the precise return type,
`ARIARoleDefinitionKey`, of functions in `src/util/implicitRoles/*`. This will assist with moving other functions and files to TypeScript that interact with third party modules such as "aria-query".