### PR TITLE
Make getImplicitRole functions return null instead of empty string

### DIFF
--- a/__tests__/src/util/implicitRoles/menu.spec.js
+++ b/__tests__/src/util/implicitRoles/menu.spec.js
@@ -7,5 +7,5 @@ test('isAbstractRole', () => {
     'toolbar',
   );
 
-  expect(getImplicitRoleForMenu([JSXAttributeMock('type', '')])).toBe('');
+  expect(getImplicitRoleForMenu([JSXAttributeMock('type', '')])).toBe(null);
 });

--- a/__tests__/src/util/implicitRoles/menuitem.spec.js
+++ b/__tests__/src/util/implicitRoles/menuitem.spec.js
@@ -15,7 +15,9 @@ test('isAbstractRole', () => {
     'menuitemradio',
   );
 
-  expect(getImplicitRoleForMenuitem([JSXAttributeMock('type', '')])).toBe('');
+  expect(getImplicitRoleForMenuitem([JSXAttributeMock('type', '')])).toBe(null);
 
-  expect(getImplicitRoleForMenuitem([JSXAttributeMock('type', true)])).toBe('');
+  expect(getImplicitRoleForMenuitem([JSXAttributeMock('type', true)])).toBe(
+    null,
+  );
 });

--- a/src/util/implicitRoles/a.js
+++ b/src/util/implicitRoles/a.js
@@ -8,5 +8,5 @@ export default function getImplicitRoleForAnchor(attributes) {
     return 'link';
   }
 
-  return '';
+  return null;
 }

--- a/src/util/implicitRoles/area.js
+++ b/src/util/implicitRoles/area.js
@@ -8,5 +8,5 @@ export default function getImplicitRoleForArea(attributes) {
     return 'link';
   }
 
-  return '';
+  return null;
 }

--- a/src/util/implicitRoles/img.js
+++ b/src/util/implicitRoles/img.js
@@ -7,7 +7,7 @@ export default function getImplicitRoleForImg(attributes) {
   const alt = getProp(attributes, 'alt');
 
   if (alt && getLiteralPropValue(alt) === '') {
-    return '';
+    return null;
   }
 
   /**
@@ -19,7 +19,7 @@ export default function getImplicitRoleForImg(attributes) {
    */
   const src = getProp(attributes, 'src');
   if (src && getLiteralPropValue(src)?.includes('.svg')) {
-    return '';
+    return null;
   }
 
   return 'img';

--- a/src/util/implicitRoles/link.js
+++ b/src/util/implicitRoles/link.js
@@ -8,5 +8,5 @@ export default function getImplicitRoleForLink(attributes) {
     return 'link';
   }
 
-  return '';
+  return null;
 }

--- a/src/util/implicitRoles/menu.js
+++ b/src/util/implicitRoles/menu.js
@@ -9,8 +9,8 @@ export default function getImplicitRoleForMenu(attributes) {
   if (type) {
     const value = getLiteralPropValue(type);
 
-    return value && value.toUpperCase() === 'TOOLBAR' ? 'toolbar' : '';
+    return value && value.toUpperCase() === 'TOOLBAR' ? 'toolbar' : null;
   }
 
-  return '';
+  return null;
 }

--- a/src/util/implicitRoles/menuitem.js
+++ b/src/util/implicitRoles/menuitem.js
@@ -17,9 +17,9 @@ export default function getImplicitRoleForMenuitem(attributes) {
       case 'RADIO':
         return 'menuitemradio';
       default:
-        return '';
+        return null;
     }
   }
 
-  return '';
+  return null;
 }


### PR DESCRIPTION
When converting the project to TypeScript, we can take this opportunity to give more precision to internal types and data structures. This changes the pattern so that `getImplicitRole*()` functions either return a valid role or `null` if the element doesn't have a role. In addition to being internally consistent, this pattern also better matches the DOM itself when accessing the "role" attribute.